### PR TITLE
Remove LinkedIn vanity badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@
     <a href="https://github.com/hansohn/terraform-digitalocean-droplet/blob/main/LICENSE">
       <img src="https://img.shields.io/github/license/hansohn/terraform-digitalocean-droplet.svg?style=for-the-badge">
     </a>
-    <!-- LinkedIn -->
-    <a href="https://linkedin.com/in/ryanhansohn">
-      <img src="https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555">
-    </a>
   </p>
 </div>
 


### PR DESCRIPTION
## what

Removes the LinkedIn badge from the README header.

## why

The badge fix was pushed to `modernize-ci-scaffolding` after #9 had already
merged, so it never reached `main`. This re-lands it on its own branch.

Aligns the badge set with `terraform-aws-module-template` and the docker repo,
neither of which carries a LinkedIn badge (header keeps Build Status, Github Tag,
License).

## references

- follow-up to #9