### PR TITLE
Fix load balancer / firewall / volume correctness bugs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -308,8 +308,11 @@ resource "digitalocean_loadbalancer" "public" {
   droplet_ids                      = digitalocean_droplet.private[*].id
   droplet_tag                      = var.public_lb_droplet_tag
   firewall {
-    deny  = var.public_lb_firewall_deny
-    allow = compact(concat(["ip:${chomp(data.http.myip[0].response_body)}"], var.public_lb_firewall_allow))
+    deny = var.public_lb_firewall_deny
+    # Only prepend the caller's detected IP when data.http.myip was actually
+    # queried (firewall_allow_myip_ssh || firewall_allow_myip_web); otherwise
+    # the count-guarded data source is empty and [0] would be out of range.
+    allow = compact(concat(length(data.http.myip) > 0 ? ["ip:${chomp(data.http.myip[0].response_body)}"] : [], var.public_lb_firewall_allow))
   }
   # dynamic "firewall" {
   #   for_each = var.public_lb_firewall
@@ -376,7 +379,7 @@ resource "digitalocean_firewall" "public" {
       destination_addresses          = lookup(outbound_rule.value, "destination_addresses", null) != null ? split(",", lookup(outbound_rule.value, "destination_addresses")) : null
       destination_droplet_ids        = lookup(outbound_rule.value, "destination_droplet_ids", null) != null ? split(",", lookup(outbound_rule.value, "destination_droplet_ids")) : null
       destination_tags               = lookup(outbound_rule.value, "destination_tags", null) != null ? split(",", lookup(outbound_rule.value, "destination_tags")) : null
-      destination_load_balancer_uids = lookup(outbound_rule.value, "destination_load_balancer_uids", null) != null ? split(",", lookup(outbound_rule.value, "destinattion_load_balancer_uids")) : null
+      destination_load_balancer_uids = lookup(outbound_rule.value, "destination_load_balancer_uids", null) != null ? split(",", lookup(outbound_rule.value, "destination_load_balancer_uids")) : null
     }
   }
 }
@@ -467,9 +470,12 @@ resource "digitalocean_project_resources" "private_droplet" {
 #--------------------------------------------------------------
 
 resource "digitalocean_volume" "private" {
-  count                    = module.private_label.enabled && var.private_volume_enabled ? var.private_droplet_count : 0
-  region                   = digitalocean_vpc.this[0].region
-  name                     = var.private_volume_name
+  count  = module.private_label.enabled && var.private_volume_enabled ? var.private_droplet_count : 0
+  region = digitalocean_vpc.this[0].region
+  # Volume names must be unique. Suffix with the index only when more than one
+  # private droplet is created so existing single-volume deployments are not
+  # renamed (which would force replacement of a data-bearing volume).
+  name                     = var.private_droplet_count > 1 ? "${var.private_volume_name}-${count.index}" : var.private_volume_name
   size                     = var.private_volume_size
   description              = var.private_volume_description
   snapshot_id              = var.private_volume_snapshot_id
@@ -570,7 +576,7 @@ resource "digitalocean_firewall" "private" {
       destination_addresses          = lookup(outbound_rule.value, "destination_addresses", null) != null ? split(",", lookup(outbound_rule.value, "destination_addresses")) : null
       destination_droplet_ids        = lookup(outbound_rule.value, "destination_droplet_ids", null) != null ? split(",", lookup(outbound_rule.value, "destination_droplet_ids")) : null
       destination_tags               = lookup(outbound_rule.value, "destination_tags", null) != null ? split(",", lookup(outbound_rule.value, "destination_tags")) : null
-      destination_load_balancer_uids = lookup(outbound_rule.value, "destination_load_balancer_uids", null) != null ? split(",", lookup(outbound_rule.value, "destinattion_load_balancer_uids")) : null
+      destination_load_balancer_uids = lookup(outbound_rule.value, "destination_load_balancer_uids", null) != null ? split(",", lookup(outbound_rule.value, "destination_load_balancer_uids")) : null
     }
   }
 }


### PR DESCRIPTION
## what

Fixes three pre-existing correctness bugs found during a code review of `main.tf`.
All are plan/apply-time failures that `terraform validate` does not catch.

### 1. Public load balancer crashes without a my-IP flag
`data.http.myip` is count-gated on `firewall_allow_myip_ssh || firewall_allow_myip_web`
(both default `false`), but the LB `firewall.allow` referenced `data.http.myip[0]`
unconditionally. Enabling `enable_public_lb` with the my-IP flags at their defaults
failed with **"index 0 out of range"**. Now guarded with `length(data.http.myip) > 0`.

### 2. Misspelled lookup key on firewall outbound rules
`destinattion_load_balancer_uids` (typo) was used in the value branch of both the
public and private firewall `destination_load_balancer_uids` rules. The condition
checked the correct key, so supplying `destination_load_balancer_uids` on an outbound
rule hit `split(",", null)` and errored. Fixed the spelling in both firewalls.

### 3. Duplicate private-volume names when `private_droplet_count > 1`
`digitalocean_volume.private` has `count = ... private_droplet_count` but named every
volume `var.private_volume_name`. DigitalOcean requires unique volume names, so apply
failed for count > 1. Now suffixes `-${count.index}` **only when count > 1**, so
existing single-volume deployments keep their name and are not forced to replace a
data-bearing volume.

## why

These are real crashes on valid configurations. They are independent of the pending
`context.tf` removal (#8), so landing them separately keeps `main.tf` churn reviewable.

## testing

- `terraform fmt -check` and `terraform validate` pass.

## references

- part of the review tracked in #8 (items #4/#5 from that review are deferred to the
  #8 refactor)
