### PR TITLE
Align Makefile to template; fix example enabled wiring + README usage

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,7 +47,7 @@ so you do not need to install it locally.
 
 2. **Start a local dev shell** (pulls the tooling image and mounts the repo):
    ```bash
-   make docker
+   make dev
    ```
 
 3. **Inside the container, validate the module:**
@@ -81,7 +81,7 @@ We welcome various types of contributions:
 
 3. Test your changes locally:
    ```bash
-   make docker
+   make dev
    # inside the container:
    terraform fmt --check
    terraform validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](unreleased)
 
-- no new features in development at this time
+IMPROVEMENTS:
+
+- align the `Makefile` with the module template conventions: a single `dev` target (`make dev`, *Run local dev env*) and a find-based `clean`, replacing `docker`/`docker-run`/`clean-docker`/`clean-terraform`
+- example: wire the `enabled` input so the fixture's `enabled = true` is no longer an undeclared-variable warning
+- docs: add a registry-source usage snippet to the README, refresh the Makefile target list, and update CONTRIBUTING (`make docker` -> `make dev`)
 
 ## [2.0.0](https://github.com/hansohn/terraform-digitalocean-droplet/compare/1.1.1...2.0.0) (Jul 11, 2026)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --warn-undefined-variables
 SHELL := bash
 .SHELLFLAGS := -eu -o pipefail -c
-.DEFAULT_GOAL := all
+.DEFAULT_GOAL := dev
 .DELETE_ON_ERROR:
 .SUFFIXES:
 
@@ -10,61 +10,53 @@ export SELF ?= $(MAKE)
 PROJECT_PATH ?= $(shell 'pwd')
 include $(PROJECT_PATH)/Makefile.*
 
-#-------------------------------------------------------------------------------
-# docker
-#-------------------------------------------------------------------------------
+# main
+export UNAME_S ?= $(shell uname -s)
+
+export DIGITALOCEAN_TOKEN ?=
+export REPO_NAME := $(shell basename ${PWD})
 
 DOCKER_IMAGE ?= hansohn/terraform-digitalocean
-DOCKER_TAG ?= latest
-ENTRYPOINT ?= bash
+DOCKER_TAG   ?= latest
+DOCKER_PULL  ?= always
 
-DOCKER_RUN_ARGS ?=
-DOCKER_RUN_ARGS += --interactive
-DOCKER_RUN_ARGS += --tty
-DOCKER_RUN_ARGS += --rm
-DOCKER_RUN_ARGS += --workdir /app
-DOCKER_RUN_ARGS += --volume ${PWD}:/app
-DOCKER_RUN_ARGS += --volume ${HOME}/.aws:/root/.aws
-DOCKER_RUN_ARGS += --volume ${HOME}/.gitconfig:/root/.gitconfig
-DOCKER_RUN_ARGS += --volume ${HOME}/.netrc:/root/.netrc
-DOCKER_RUN_ARGS += --pull always
+DOCKER_ARGS ?=
+DOCKER_ARGS += --interactive
+DOCKER_ARGS += --tty
+DOCKER_ARGS += --rm
+DOCKER_ARGS += --env DIGITALOCEAN_TOKEN
+DOCKER_ARGS += --env REPO_NAME
+DOCKER_ARGS += --workdir /app
+DOCKER_ARGS += --volume ${PWD}:/app
+DOCKER_ARGS += --volume ${HOME}/.ssh/known_hosts:/root/.ssh/known_hosts
+DOCKER_ARGS += --volume ${HOME}/.gitconfig:/root/.gitconfig:ro
+DOCKER_ARGS += --pull $(DOCKER_PULL)
 
-## Docker run image
-docker/run:
-	-@if docker info > /dev/null 2>&1; then \
-		echo "[INFO] Running '$(DOCKER_IMAGE):$(DOCKER_TAG)' docker image"; \
-		docker run $(DOCKER_RUN_ARGS) "$(DOCKER_IMAGE):$(DOCKER_TAG)" "$(ENTRYPOINT)"; \
-	else \
-		echo "[ERROR] Docker 'run' failed. Docker daemon is not Running."; \
-	fi
-.PHONY: docker/run
+SSH_AUTH_SOCK_MAGIC_PATH := /run/host-services/ssh-auth.sock
+ifeq ($(UNAME_S),Darwin)
+DOCKER_ARGS += --env SSH_AUTH_SOCK=$(SSH_AUTH_SOCK_MAGIC_PATH)
+DOCKER_ARGS += --volume $(SSH_AUTH_SOCK_MAGIC_PATH):$(SSH_AUTH_SOCK_MAGIC_PATH)
+endif
 
-## Docker lint, build and run image
-docker: docker/run
-.PHONY: docker
 
-#-------------------------------------------------------------------------------
-# clean
-#-------------------------------------------------------------------------------
+## Run local dev env
+dev: ENTRYPOINT ?= bash
 
-## Clean docker build images
-clean/docker:
-	-@if docker info > /dev/null 2>&1; then \
-		if docker inspect --type=image "$(DOCKER_IMAGE):$(DOCKER_TAG)" > /dev/null 2>&1; then \
-		echo "[INFO] Removing docker image '$(DOCKER_IMAGE):$(DOCKER_TAG)'"; \
-			docker rmi -f $$(docker inspect --format='{{ .Id }}' --type=image $(DOCKER_IMAGE):$(DOCKER_TAG)); \
-		fi; \
-	fi
-.PHONY: clean/docker
+dev:
+	docker run \
+		$(DOCKER_ARGS) \
+		$(DOCKER_IMAGE):$(DOCKER_TAG) \
+		$(ENTRYPOINT)
 
-TG_GENERATED_FILES += .terraform .terraform.lock.hcl .terragrunt-cache
-## Clean terraform generated files/directories
-clean/terraform:
-	-@for i in $(TG_GENERATED_FILES); do \
-		find . -name "$$i" -prune -exec rm -rf {} \;; \
-	done
-.PHONY: clean/terraform
+.PHONY: dev
+
+CLEAN_DIRS  += .terraform
+CLEAN_FILES += .terraform.lock.hcl terraform.plan
+$(CLEAN_DIRS):
+	find . -type d -name $@ -prune -exec rm -rf {} \;
+$(CLEAN_FILES):
+	find . -type f -name $@ -exec rm -f {} \;
 
 ## Clean everything
-clean: clean/docker clean/terraform
-.PHONY: clean
+clean: $(CLEAN_DIRS) $(CLEAN_FILES)
+.PHONY: clean $(CLEAN_DIRS) $(CLEAN_FILES)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,29 @@
 
 ## :open_book: Usage
 
-Welcome to the terraform-digitalocean-droplet repo!
+```hcl
+module "droplet" {
+  source  = "hansohn/droplet/digitalocean"
+  version = "~> 2.0"
+
+  name = "example-dev"
+  tags = ["example", "dev"]
+
+  # vpc
+  vpc_region   = "sfo3"
+  vpc_ip_range = "10.10.10.0/24"
+
+  # internet gateway (NAT) droplet
+  igw_droplet_image = "ubuntu-22-04-x64"
+
+  # private droplets routed through the gateway
+  private_droplet_image = "ubuntu-22-04-x64"
+  private_droplet_count = 2
+}
+```
+
+Authenticate by exporting `DIGITALOCEAN_TOKEN` (used by both the Terraform provider and
+`doctl`). See the [complete example](examples/complete) for the full set of inputs.
 
 
 ### Makefile
@@ -30,10 +52,7 @@ I've included the following make targets for convenience:
 Available targets:
 
   clean                               Clean everything
-  clean/docker                        Clean docker build images
-  clean/terraform                     Clean terraform generated files/directories
-  docker                              Docker lint, build and run image
-  docker/run                          Docker run image
+  dev                                 Run local dev env
   help                                Help screen
   help/all                            Display help for all targets
   help/short                          This help short screen

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,8 +10,9 @@ module "igw" {
   source = "../../"
 
   # general
-  name = var.name
-  tags = var.tags
+  enabled = var.enabled
+  name    = var.name
+  tags    = var.tags
 
   # ssh-key
   generate_ssh_key       = var.generate_ssh_key

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -18,6 +18,12 @@ variable "name" {
   description = "Base name used to derive resource names."
 }
 
+variable "enabled" {
+  type        = bool
+  default     = true
+  description = "Set to false to prevent the module from creating any resources."
+}
+
 variable "tags" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
## what

Post-2.0.0 consistency polish.

### Makefile (aligns with terraform-aws-module-template)
- Replace `docker` / `docker/run` / `clean/docker` / `clean/terraform` with the template's
  **`dev`** (`.DEFAULT_GOAL := dev`, *Run local dev env*) and a find-based **`clean`**.
- Adapt docker args for DigitalOcean: pass `DIGITALOCEAN_TOKEN`, drop the vestigial `.aws`/`.netrc`
  mounts, add read-only `.gitconfig`, `known_hosts`, and macOS SSH-agent forwarding.

### Example
- Wire the `enabled` input (declare `variable "enabled"` + `enabled = var.enabled`). The fixture
  set `enabled = true` but it was never declared/passed after the context.tf removal, so it was an
  undeclared-variable warning.
- Keeps `source = "../../"` so CI validates the local module (matches the template).

### Docs
- README: refresh the Makefile target list; add a **registry-source Usage snippet**
  (`source = "hansohn/droplet/digitalocean"`, `version = "~> 2.0"`) for consumers.
- CONTRIBUTING: `make docker` -> `make dev`.

## testing

- `terraform fmt -check`, `tflint`, and `terraform validate` pass for root, ssh-key, and example.
- `terraform-docs` output-check passes.