### PR TITLE
Promote CHANGELOG to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](unreleased)
 
+- no new features in development at this time
+
+## [2.0.1](https://github.com/hansohn/terraform-digitalocean-droplet/compare/2.0.0...2.0.1) (Jul 11, 2026)
+
 IMPROVEMENTS:
 
 - align the `Makefile` with the module template conventions: a single `dev` target (`make dev`, *Run local dev env*) and a find-based `clean`, replacing `docker`/`docker-run`/`clean-docker`/`clean-terraform`


### PR DESCRIPTION
Promotes the `[Unreleased]` changelog block (Makefile alignment, example `enabled` wiring, README usage snippet) to a `2.0.1` section ahead of cutting the tag.

Docs/tooling only — the module's Terraform is unchanged from 2.0.0. The tag will refresh the public-registry README with the new usage snippet.