### PR TITLE
Lower architecture diagram width to 600

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ droplets for inbound web traffic, and an optional bastion role on the gateway pr
 hardened SSH ingress.
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/hansohn/terraform-digitalocean-droplet/main/docs/architecture.drawio.png" alt="terraform-digitalocean-droplet architecture" width="820">
+  <img src="https://raw.githubusercontent.com/hansohn/terraform-digitalocean-droplet/main/docs/architecture.drawio.png" alt="terraform-digitalocean-droplet architecture" width="600">
 </div>
 
 <!-- Diagram source: docs/architecture.drawio — edit in draw.io / diagrams.net, then File > Export as > PNG to docs/architecture.drawio.png. -->


### PR DESCRIPTION
The `docs/architecture.drawio.png` export is 602px wide, but the README displayed it at `width=820` — upscaling a raster, so it rendered oversized and blurry. Set `width=600` (native) so it's appropriately sized and sharp.

Docs-only. For retina crispness later, re-export the diagram at 2x zoom and keep width=600.