### PR TITLE
Promote CHANGELOG to 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](unreleased)
 
+- no new features in development at this time
+
+## [2.0.2](https://github.com/hansohn/terraform-digitalocean-droplet/compare/2.0.1...2.0.2) (Jul 13, 2026)
+
 IMPROVEMENTS:
 
+- docs: replace the Mermaid architecture diagram with a draw.io image using DigitalOcean resource icons, so it renders on the Terraform Registry and other platforms (not just GitHub)
 - ssh-key: document that `generate_ssh_key` stores the generated private key in Terraform state (and on disk when `local_download_enabled` is true); recommend importing/referencing an existing key for production
 
 ## [2.0.1](https://github.com/hansohn/terraform-digitalocean-droplet/compare/2.0.0...2.0.1) (Jul 11, 2026)


### PR DESCRIPTION
Promotes the `[Unreleased]` block to `2.0.2` ahead of tagging: the draw.io architecture diagram (#20) and the ssh-key state-secret documentation caveat (#19). Docs only — the module Terraform is unchanged from 2.0.1.